### PR TITLE
Fixed Catch-up exam (2023 / S2)

### DIFF
--- a/2023/S2/EXAMS.md
+++ b/2023/S2/EXAMS.md
@@ -40,4 +40,4 @@ _Pas d'information pour le moment._
 
 ## Rattrapages Partiels
 
-Prévus entre le 10 et le 15 juillet. (?)
+Prévus entre le 9 et le 10 juillet. (?)

--- a/2023/S2/EXAMS.md
+++ b/2023/S2/EXAMS.md
@@ -40,4 +40,4 @@ _Pas d'information pour le moment._
 
 ## Rattrapages Partiels
 
-Prévus entre le 9 et le 10 juillet. (?)
+Prévus le 9 et le 10 juillet.


### PR DESCRIPTION
Updated to correct dates for the catch-up exams (at the end of S2).

- Updated `2023/S2/EXAMS.md`